### PR TITLE
Qt Creator セットアップガイドを翻訳

### DIFF
--- a/setup/msys2/index.html.mako
+++ b/setup/msys2/index.html.mako
@@ -1,114 +1,108 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="/_templates/markdown.mako" />
 
-[openFrameworks](http://openframeworks.cc/) | [Documentation table of contents](table_of_contents.md)
+[openFrameworks](http://openframeworks.cc/) | [ドキュメント目次](table_of_contents.md)
 
 MSYS2
 =====
 
-Installing MSYS2 
+MSYS2のインストール 
 ----------------
 
-First, install MSYS2 using the [one-click installer](https://msys2.github.io/) or 
-directly unzipping the archive from their [repository](http://sourceforge.net/projects/msys2/files/Base/x86_64/)
+まず[公式ページ](https://msys2.github.io/)か[リポジトリ](http://sourceforge.net/projects/msys2/files/Base/x86_64/)からインストーラーをダウンロードしてインストールします。
 
-If you are going to use QtCreator you should install msys2 in the default install folder, c:\msys64
+Qt Creatorを使うつもりであれば、msys2はデフォルトの場所(c:\msys64)にインストールされている必要があります。
 
-Open a MSYS2 shell and update the system packages :
+インストールが済んだらMSYS2のシェルを起動してシステムパッケージを更新してください。
 
     pacman --noconfirm  --needed -Sy bash pacman pacman-mirrors msys2-runtime
 	
-Close the shell and open a new one to update the remaining packages :
+シェルを再起動し、残りのパッケージを更新します。
 
     pacman --noconfirm -Su
 
-You are now ready to install openFrameworks.	
+これでopenFrameworksをインストールする準備ができました。	
 
 
-Installing openFrameworks
+openFrameworksのインストール
 -------------------------
 
-Download and unzip the win_cb version of oF.
+qt creator / msys2版のoFをダウンロードして解凍してください。
 
-Open an MSYS shell and install OF dependencies:
+MSYSシェルを起動して依存関係のインストールをおこないます。
 
-    cd your_oF_directory/scripts/win_cb/msys2
+    cd your_oF_directory/scripts/msys2
     ./install_dependencies.sh`
+    
+**MINGW32シェル（MinGw-w64 Win32 Shell）**を起動してライブラリをコンパイルします。
 	
-Open an **MINGW32** shell and compile oF libraries:
-
 	cd your_oF_directory/libs/openFrameworksCompiled/project
     make
 
-You can speed-up compilation using parallel build `make -j4` or the number of cores you want it to use
+`make -j4`とすることで複数コアを使った並列ビルドも可能です(数字部分は使いたいコア数に応じて変更してください)。
 
 
-Setting the PATH variable
+PATH環境変数の設定
 -------------------------
-On MSYS2, openFrameworks needs the dlls that are provided by MSYS2 package manager `pacman`. The PATH variable tells the system where to look for these dlls. On Windows, the system starts to look into the executable folder, then into the folders defined in system PATH and finally into the folders defined in user PATH.
 
-You can find how to set the PATH in windows here: http://www.computerhope.com/issues/ch000549.htm
+MSYS2とともにopenFrameworksを使うためにはMSYS2のパッケージマネージャーである`pacman`が提供するいくつかのDLLが必要になります。PATH環境変数はDLLの場所をシステムに教えるためのものです。Windowsでは、実行ファイルはカレントディレクトリ、システム環境変数で定義されたPATH、ユーザー環境変数で定義されたPATHの順に探索されます。
 
-You'll need to add your_msys2_directory\mingw32\bin;your_msys2_directory\usr\bin to your PATH, which usually is:
+PATH環境変数の設定方法は[こちら](http://www.computerhope.com/issues/ch000549.htm)を参照してください。
 
-        c:\msys64\mingw32\bin;c:\msys64\usr\bin
-        
-You can also set the PATH from the command line: open a Windows cmd prompt and set you user PATH
+ここでは your_msys2_directory\mingw32\bin;your_msys2_directory\usr\bin をPATHに加える必要があります。これは通常
 
-        setx PATH "%PATH%;your_msys2_directory\mingw32\bin;your_msys2_directory\usr\bin;"
+	c:\msys64\mingw32\bin;c:\msys64\usr\bin
+	
+となるでしょう。
 
-If you have administrative privileges, you can directly set the system PATH. All users will benefit of it...
+コマンドラインから設定することもできます。コマンドプロンプトを起動してユーザーPATH環境変数を設定しましょう。
 
-That's all, now go to the your_oF_directory/examples folder, where you will find 
-the examples, and have fun! 
+	setx PATH "%PATH%;your_msys2_directory\mingw32\bin;your_msys2_directory\usr\bin;"
+	
+もし管理者権限を持っていればシステム環境変数の設定も可能です。この場合、すべてのユーザーが恩恵を受けることができるでしょう。
 
-Running examples
+これで完了です。まずはサンプルプロジェクトを楽しんでみてください！
+
+サンプルプロジェクトの実行
 ----------------
-Compile the example (for example the 3DPrimitivesExample)
+例として3DPrimitivesExampleをコンパイルしてみましょう。
 
     cd your_oF_directory/examples/3d/3DPrimitivesExample
     make
 
-At this point, `make run` or  double-click on the exe file to launch. 
+`make run`と打つかダブルクリックしてアプリケーションを起動してください。
 
 
 Makefile
 --------
 
-Every example has a Makefile you can configure using the files config.make
-and addons.make.
+すべてのサンプルプロジェクトにはMakefileがあり、config.makeファイルおよびaddons.makeファイルを使用して設定をおこなうことができます。
 
-config.make: This file has options to add search paths, libraries, etc., the 
-syntax is the usual syntax in makefiles, there's help comments inside the file.
+config.make: 一般的なMakefileの記法を使ってサーチパスやライブラリの追加をおこなうためのファイルです。ファイル内のコメントを参考にしてください。
 
-addons.make: if you want to use an addon which is inside the addons folder, just 
-add its name in a new line in this file.
+addons.make: アドオンを使いたい場合は、そのアドオンの名前をこのファイルに書き加えます。
 
 QtCreator
 ---------
 
-With msys2 you can also use QtCreator as an IDE, you can find more information in the corresponding [setup guide](../qtcreator):
+IDEとしてQt Creatorを使用することもできます。詳しくは[セットアップガイド](../qtcreator)を参照してください。
 
-FAQ / Common problems
+よくある質問
 --------------------- 
-- "I have a TLSv1_1_client_method missing error" when I double-click the exe ?"
+- exeファイルをダブルクリックすると "TLSv1_1_client_method missing" というエラーが出ます。
 
-The executable looks for ssleay32.dll and libeay32.dll and it first finds a version that doesn't support TLS v1.1. Often it happens with Intel iCls software. The solution is to move the your_msys2_directory\mingw32\bin path before the conflicting path. If the conflicting path is in the system PATH and you do not have administrative privileges, copy/link ssleay32.dll and libeay32.dll from your_msys2_directory\mingw32\bin to the executable folder.
+実行ファイルが見つけたssleay32.dllおよびlibeay32.dllがTLS v1.1をサポートしていないために出るエラーで、Intel iClsソフトウェアでよく起こります。解決するにはyour_msys2_directory\mingw32\binのパスを衝突しているパスより前に移動させます。衝突しているパスがシステム環境変数の中にあり、管理者権限を持っていない場合は、ssleay32.dllとlibeay32.dllをyour_msys2_directory\mingw32\binからexeファイルのあるフォルダにコピーもしくはリンクしてください。
 
-- "I'm on a corporate network with a proxy. I cannot download packages with pacman."
+- 会社のネットワークにプロキシが設定されているため、pacmanからパッケージをダウンロードできません。
 
-You may need to set HTTP_PROXY and HTTPS_PROXY environment variables.
+HTTP\_PROXYおよびHTTPS\_PROXY環境変数を設定する必要があります。コマンドプロンプトで以下のように打ち込んでください。
 
-    From a DOS/CMD prompt :    
-    set http_proxy=http://your_proxy:your_port
-    set http_proxy=http://username:password@your_proxy:your_port
-    set https_proxy=https://your_proxy:your_port
-    set https_proxy=https://username:password@your_proxy:your_port
-Don't forget to escape special characters in your password...
-
-
-
- 
+	set http_proxy=http://your_proxy:your_port
+	set http_proxy=http://username:password@your_proxy:your_port
+	set https_proxy=https://your_proxy:your_port
+	set https_proxy=https://username:password@your_proxy:your_port
+	
+パスワードに含まれる特殊文字をエスケープするのをお忘れなく。
 
 many thanks!! OFteam
 

--- a/setup/qtcreator/index.html.mako
+++ b/setup/qtcreator/index.html.mako
@@ -4,24 +4,29 @@
 Qt Creator
 ==========
 
-Since version 0.9.0 we have support for Qt Creator in Linux, Windows and OSX. This guide is based on Qt Creator 3.5.1 and a different version might have different steps to follow or not work as expected.
+LinuxとWindows、そしてOSX向けに、バージョン0.9.0からQt Creatorに対応しました。このガイドはQt Creator 3.5.1をベースにしており、その他のバージョンでは手順が異なったり、期待通りに動かない可能性があります。
 
-You can download Qt Creator from: [http://www.qt.io/download-open-source/#section-6](http://www.qt.io/download-open-source/#section-6)
+Qt Creatorは以下のリンクからダウンロードすることができます。  
+[http://www.qt.io/download-open-source/#section-6](http://www.qt.io/download-open-source/#section-6)
 
 
 Linux
 -----
 
-Before using OF in linux you need to run some install scripts, follow the instructions [here](../linux-install/) if you haven't done so yet.
+LinuxでOFを使うためにはいくらか準備が必要です。まだセットアップが済んでいない場合は[こちらのガイド](../linux-install)を参照しながらおこなってください。
 
-In linux even if Qt Creator is available in the official repositories for your distributions, it's recommended to install qtcreator from their webpage instead. The one that comes with the distribution (at least in ubuntu) might be outdated and installing the one from the webpage you'll get support for the clang plugin which analizes the code while you type marking any errors more accurately than the default qtcreator static analizer. 
+LinuxでQt Creatorを使用する場合、ディストリビューションのリポジトリに存在するものよりもWebページで配布されているものをインストールすることをおすすめします。ディストリビューションから手に入るバージョン（少なくともUbuntu版）は古くなっている可能性がありますが、Webページからダウンロードできるバージョンでは、デフォルトの静的解析ツールに比べてより正確にエラー箇所を教えてくれるclangプラグインのサポートが得られます。
 
-Once installed you can install the Qt Creator plugin for openFrameworks that comes with the OF download, you can run the install_template.sh script in scripts/qtcreator and it'll install everything for you.
+いったんインストールが済めば、openFrameworks向けのQt Creatorプラグインのインストールができます。scripts/qtcreator 内にある install_template.sh を実行すれば必要なものがすべてインストールされるでしょう。
 
 Windows
 ----
 
-First of all you'll need to install msys2. Follow the instructions in the [setup guide for msys2](../msys2)
+まずはじめにmsys2をインストールする必要があります。[セットアップガイド](../msys2)を参照してください。
+
+ビルドシステムはmsys2がデフォルトのディレクトリ（c:\msys64）にあることを期待します。もし他の場所にインストールされている場合はプロジェクトファイルの修正が必要になるかもしれません。
+
+msys2を利用してQt Creator使うには、メニューから**ツール > オプション**を開いて**ビルドと実行**メニューから**コンパイラ**タブを選択し、リストに**c:\msys64\mingw32\bin**がなければ追加します。**キット**タブへ移動し、
 
 Some parts of the build system rely on msys2 being installed in the default folder: c:\msys64 and installing it somewhere else might need modifications to the project files.
 
@@ -32,25 +37,26 @@ Once installed you can install the Qt Creator plugin for openFrameworks that com
 OSX
 ----
 
-After installing QtCreator go to Qt Creator > Preferences > Build and Run and configure the Desktop Kit to use clang instead of gcc. If you can't change it from there, press manage or go to the Compilers tab and check that clang is available. You might need to add a custom config to be able to enable clang instead of GCC.
+Qt Creatorをインストールして起動したら、メニューバーから**Qt Creator > 設定（⌘+,）**を開きます。**ビルドと実行**メニューから**キット**タブを選択し、gccではなくclangを使用するよう設定をおこなってください。設定が変更できない場合は「管理」ボタンを押すか直接**コンパイラ**タブへ移動し、clangが有効になっているか確認します。場合によっては独自の設定を追加する必要があるかもしれません。
 
-Once installed you can install the Qt Creator plugin for openFrameworks that comes with the OF download, you can run the install_template.sh script in scripts/qtcreator and it'll install everything for you.
+いったんインストールが済めば、openFrameworks向けのQt Creatorプラグインのインストールができます。scripts/qtcreator 内にある install_template.sh を実行すれば必要なものがすべてインストールされるでしょう。
 
-All platforms
+すべてのプラットフォーム
 -------------
 
-Optionally you can enabled the Clang static analizer which is more accurate finding errors in the code while you type but it's also sometimes slower. To enable it, from qt's page:
+必要に応じてClangの静的解析ツールを有効にすることができます。これはコーディング中に正確にエラーを発見してくれるものですが、速度の低下につながることもあります。Qtのページから、これを有効化する手順を紹介します。
 
-Configuring Clang Code Model Plugin
+Clang コードモデル用プラグインの設定
 
-  - Select Help > About Plugins > C++ > ClangCodeModel to enable the plugin.
-  - Restart Qt Creator to be able to use the plugin.
-  - Select Tools > Options > C++ > Code Model, and select the parser to use for files of each type. (Set everything to Clang)
+  - メニューバーから **Qt Creator > プラグインについて...** を選択してプラグインの一覧を開き、**C++ > Clang Code Model** のチェックボックスを選択します。
+  - Qt Creatorを再起動します。
+  - メニューバーから **設定... > C++ > コードモデルの確認...** を開いて、すべてのオプションをClangに変更します。
 
-The openFrameworks plugin allows to create new projects and add official addons through a wizard, once the project is created you can edit the .qbs project file to easily add any new addons just by adding their name in the of.addons array.
+openFrameworksプラグインをインストールすると、ウィザードに従って新規プロジェクトの作成と公式アドオンの追加がおこなえます。プロジェクトを作成したあとは**.qbs**ファイル内にある**of.addons**という配列にアドオンの名前を加えることでそのアドオンを追加することができます。
 
-There's a second project type in the wizard that allows to create a project from existing code.
+また、既存のコードからプロジェクトを作成することも可能です。
 
-A project created in any platform will work right away in any of the other supported platforms
+あるプラットフォーム上で作成したプロジェクトは、サポートされるその他のプラットフォームでも動作するはずです。
+
 
 <iframe src="https://player.vimeo.com/video/142272907" width="1000" height="563" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/setup/qtcreator/index.html.mako
+++ b/setup/qtcreator/index.html.mako
@@ -26,13 +26,9 @@ Windows
 
 ビルドシステムはmsys2がデフォルトのディレクトリ（c:\msys64）にあることを期待します。もし他の場所にインストールされている場合はプロジェクトファイルの修正が必要になるかもしれません。
 
-msys2を利用してQt Creator使うには、メニューから**ツール > オプション**を開いて**ビルドと実行**メニューから**コンパイラ**タブを選択し、リストに**c:\msys64\mingw32\bin**がなければ追加します。**キット**タブへ移動し、
+msys2とともにQt Creatorを使うには、メニューから**ツール > オプション**を開いて**ビルドと実行**メニューから**コンパイラ**タブを選択し、コンパイラのリストに**c:\msys64\mingw32\bin**がなければ追加します。その後、**キット**タブへ移動してデスクトップキットがmsys2からgccを使用するように設定します。
 
-Some parts of the build system rely on msys2 being installed in the default folder: c:\msys64 and installing it somewhere else might need modifications to the project files.
-
-To use QtCreator with msys2 go to Qt Creator > Preferences > Build and Run > Compilers and if it's not there add a compiler that points to c:\msys64\mingw32\bin then in the Kits tab configure the Desktop Kit to use gcc from msys2.
-
-Once installed you can install the Qt Creator plugin for openFrameworks that comes with the OF download by copying the templates in scripts/qtcreator/templates to c:\Qt\qtcreator-3.5.1\share\qtcreator\templates.
+最後にscripts/qtcreator/templatesフォルダ内のテンプレートをc:\Qt\qtcreator-3.5.1\share\qtcreator\templatesにコピーしてopenFrameworksのためのQt Creatorプラグインをインストールしましょう。
 
 OSX
 ----


### PR DESCRIPTION
- Qt Creator セットアップガイド
- MSYS2 セットアップガイド ( Windows 向け )

を翻訳しました。Linux および Windows はあまり馴染みがないためおかしな部分があるかもしれません。。